### PR TITLE
Add React Router v2, add defaults to the index.jsx

### DIFF
--- a/lib/client/index.jsx
+++ b/lib/client/index.jsx
@@ -1,0 +1,8 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+import { Router, Route, browserHistory, Link } from 'react-router'
+
+ReactDOM.render(
+  <Router history={browserHistory}>
+  </Router>
+, document.getElementById('root'))

--- a/lib/package.json
+++ b/lib/package.json
@@ -11,10 +11,9 @@
   },
 
   "dependencies": {
-    "history":      "*",
     "react":        "*",
     "react-dom":    "*",
-    "react-router": "*"
+    "react-router": "^2.0.0-rc4",
   },
 
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name":        "outset-react",
-  "version":     "2.0.0",
+  "version":     "2.1.0",
   "description": "A boilerplate for React libraries, built with webpack.",
   "homepage":    "https://github.com/callmecavs/outset-react",
 


### PR DESCRIPTION
React router removes the need to have an extra dependency of history, and also provides some other out of the box features.
